### PR TITLE
PULL de TESTE, Ajustes no Bloco 0, Registros 0190 e 0200

### DIFF
--- a/SpedBr/SpedBr.Common/EscreverCamposSpedByAttribute.cs
+++ b/SpedBr/SpedBr.Common/EscreverCamposSpedByAttribute.cs
@@ -88,7 +88,7 @@ namespace SpedBr.Common
 
                         // Verificação necessária p/ ajustes no tamanho de campos como CSTs e Indicadores. Ex.: CST PIS '1' -> Deve estar no arquivo como '01'.
                         var isCodeOrNumberAndHasLength = (spedCampoAttr.Tipo == "C" || spedCampoAttr.Tipo == "N") &&
-                                                         (spedCampoAttr.Tamanho > 0 && spedCampoAttr.Tamanho <= 10);
+                                                         (spedCampoAttr.Tamanho > 0 && spedCampoAttr.Tamanho <= 4);
 
                         var isHour = spedCampoAttr.Tipo == "H";
                         var onlyMonthAndYear = spedCampoAttr.Tipo == "MA";

--- a/SpedBr/SpedBr.SpedFiscal/Bloco0.cs
+++ b/SpedBr/SpedBr.SpedFiscal/Bloco0.cs
@@ -546,6 +546,14 @@ namespace SpedBr.SpedFiscal
             /// </summary>
             [SpedCampos(12, "ALIQ_ICMS", "N", 6, 2, false)]
             public decimal AliqIcms { get; set; }
+
+            /// <summary>
+            ///     Código Especificador da Substituição Tributária
+            ///     Guia Prático EFD-ICMS/IPI – Versão 2.0.20
+            ///     Atualização: 07/12/2016
+            /// </summary>
+            [SpedCampos(13, "CEST", "C", 7, 0, false)]
+            public string Cest { get; set; }
         }
 
         /// <summary>

--- a/SpedBr/SpedBr.SpedFiscal/Bloco0.cs
+++ b/SpedBr/SpedBr.SpedFiscal/Bloco0.cs
@@ -776,7 +776,7 @@ namespace SpedBr.SpedFiscal
             /// <summary>
             ///     Descrição da natureza da operação/prestação
             /// </summary>
-            [SpedCampos(3, "DESCR_NAT", "C", 0, 0, true)]
+            [SpedCampos(3, "DESCR_NAT", "C", int.MaxValue, 0, true)]
             public string DescrNat { get; set; }
         }
 
@@ -806,7 +806,7 @@ namespace SpedBr.SpedFiscal
             ///     referências pertinentes com indicação referentes ao
             ///     tributo.
             /// </summary>
-            [SpedCampos(3, "TXT", "C", 0, 0, true)]
+            [SpedCampos(3, "TXT", "C", int.MaxValue, 0, true)]
             public string Txt { get; set; }
         }
 

--- a/SpedBr/SpedBr.SpedFiscal/Bloco0.cs
+++ b/SpedBr/SpedBr.SpedFiscal/Bloco0.cs
@@ -461,7 +461,7 @@ namespace SpedBr.SpedFiscal
             /// <summary>
             ///     Descrição da unidade de medida.
             /// </summary>
-            [SpedCampos(3, "DESCR", "C", 0, 0, true)]
+            [SpedCampos(3, "DESCR", "C", int.MaxValue, 0, true)]
             public string Descr { get; set; }
         }
 
@@ -487,7 +487,7 @@ namespace SpedBr.SpedFiscal
             /// <summary>
             ///     Descrição do item.
             /// </summary>
-            [SpedCampos(3, "DESCR_ITEM", "C", 0, 0, true)]
+            [SpedCampos(3, "DESCR_ITEM", "C", int.MaxValue, 0, true)]
             public string DescrItem { get; set; }
 
             /// <summary>

--- a/SpedBr/SpedBr.SpedFiscal/Bloco1.cs
+++ b/SpedBr/SpedBr.SpedFiscal/Bloco1.cs
@@ -1781,25 +1781,26 @@ namespace SpedBr.SpedFiscal
             [SpedCampos(10, "MES_REF", "MA", 6, 0, true)]
             public DateTime MesRef { get; set; }
         }
-    }
 
-    /// <summary>
-    ///     REGISTRO 1990: ENCERRAMENTO DO BLOCO 1
-    /// </summary>
-    public class Registro1990 : RegistroBaseSped
-    {
         /// <summary>
-        ///     Inicializa uma nova instância da classe <see cref="Registro1990" />.
+        ///     REGISTRO 1990: ENCERRAMENTO DO BLOCO 1
         /// </summary>
-        public Registro1990()
+        public class Registro1990 : RegistroBaseSped
         {
-            Reg = "1990";
+            /// <summary>
+            ///     Inicializa uma nova instância da classe <see cref="Registro1990" />.
+            /// </summary>
+            public Registro1990()
+            {
+                Reg = "1990";
+            }
+
+            /// <summary>
+            ///     Quantidade total de linhas do Bloco 1.
+            /// </summary>
+            [SpedCampos(2, "QTD_LIN_1", "N", int.MaxValue, 0, true)]
+            public int QtdLin1 { get; set; }
         }
 
-        /// <summary>
-        ///     Quantidade total de linhas do Bloco 1.
-        /// </summary>
-        [SpedCampos(2, "QTD_LIN_1", "N", int.MaxValue, 0, true)]
-        public int QtdLin1 { get; set; }
     }
 }

--- a/SpedBr/SpedBr.SpedFiscal/Bloco9.cs
+++ b/SpedBr/SpedBr.SpedFiscal/Bloco9.cs
@@ -49,7 +49,7 @@ namespace SpedBr.SpedFiscal
             /// <summary>
             ///     Total de registros do tipo informado no campo anterior.
             /// </summary>
-            [SpedCampos(3, "QTD_REG_BLC", "N", 0, 0, true)]
+            [SpedCampos(3, "QTD_REG_BLC", "N", int.MaxValue, 0, true)]
             public int QtdRegBlc { get; set; }
         }
 
@@ -69,7 +69,7 @@ namespace SpedBr.SpedFiscal
             /// <summary>
             ///     Quantidade total de linhas do Bloco 9.
             /// </summary>
-            [SpedCampos(2, "QTD_LIN_9", "N", 0, 0, true)]
+            [SpedCampos(2, "QTD_LIN_9", "N", int.MaxValue, 0, true)]
             public int QtdLin9 { get; set; }
         }
 

--- a/SpedBr/SpedBr.SpedFiscal/BlocoC.cs
+++ b/SpedBr/SpedBr.SpedFiscal/BlocoC.cs
@@ -62,7 +62,7 @@ namespace SpedBr.SpedFiscal
             ///     - do emitente do documento ou do remetente das mercadorias, no caso de entradas;
             ///     - do adquirente, no caso de saídas.
             /// </summary>
-            [SpedCampos(4, "COD_PART", "C", 60, 0, true)]
+            [SpedCampos(4, "COD_PART", "C", 60, 0, false)]
             public string CodPart { get; set; }
 
             /// <summary>


### PR DESCRIPTION
Foram ajustados para sair as devidas descrições da UNIDADE de MEDIDA no registro 0190,
e a do PRODUTO no registro 0200, por via das dúvidas peço aos colaboradores @danielgamajpa @samuelroliveira @douglashferreira que relevem se for bobagem o que eu fiz, foi só mais para testar o PULL request.